### PR TITLE
Darkens elements in Fight when using menu

### DIFF
--- a/core/src/fr/mmyumu/troncgame/fight/FightBackground.java
+++ b/core/src/fr/mmyumu/troncgame/fight/FightBackground.java
@@ -5,8 +5,6 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 
-import javax.inject.Inject;
-
 import fr.mmyumu.troncgame.Constants;
 
 /**
@@ -16,14 +14,27 @@ import fr.mmyumu.troncgame.Constants;
 public class FightBackground extends Actor {
 
     private AssetManager assetManager;
+    private boolean darkened;
 
-    @Inject
     public FightBackground(AssetManager assetManager) {
         this.assetManager = assetManager;
     }
 
     @Override
     public void draw(Batch batch, float parentAlpha) {
+        super.draw(batch, parentAlpha);
+        if (darkened) {
+            batch.setColor(0.5f, 0.5f, 0.5f, 1f);
+        } else {
+            batch.setColor(1f, 1f, 1f, 1f);
+        }
         batch.draw(assetManager.get(FightConstants.TexturePath.BACKGROUND_PLAIN, Texture.class), 0, 0, Constants.WIDTH, Constants.HEIGHT);
+        if (darkened) {
+            batch.setColor(1f, 1f, 1f, 1f);
+        }
+    }
+
+    public void setDarkened(boolean darkened) {
+        this.darkened = darkened;
     }
 }

--- a/core/src/fr/mmyumu/troncgame/fight/FightCharacter.java
+++ b/core/src/fr/mmyumu/troncgame/fight/FightCharacter.java
@@ -31,6 +31,8 @@ public class FightCharacter extends FightCharacterLogic {
     private final Label label;
     private final LinkedList<Integer> queueDamages;
 
+    private boolean darkened;
+
     public FightCharacter(Skin skin, int x, int y, GameCharacter character, Texture texture, boolean hasFightPopUpMenu) {
         super(x, y, character);
         this.texture = texture;
@@ -58,10 +60,19 @@ public class FightCharacter extends FightCharacterLogic {
     @Override
     public void draw(Batch batch, float parentAlpha) {
         super.draw(batch, parentAlpha);
+
+        if(darkened) {
+            batch.setColor(0.5f, 0.5f, 0.5f, 1f);
+        }
+
         if (getCharacter().getHp() > 0) {
             batch.draw(texture, getX(), getY(), FightConstants.CHARACTER_WIDTH, FightConstants.CHARACTER_HEIGHT);
         }
         label.draw(batch, parentAlpha);
+
+        if(darkened) {
+            batch.setColor(1f, 1f, 1f, 1f);
+        }
     }
 
     public boolean hasFightPopUpMenu() {
@@ -105,5 +116,9 @@ public class FightCharacter extends FightCharacterLogic {
         label.setColor(1f, 0.1f, 0.1f, 1f);
         label.setText(String.valueOf(damage));
         label.addAction(action);
+    }
+
+    public void setDarkened(boolean darkened) {
+        this.darkened = darkened;
     }
 }

--- a/core/src/fr/mmyumu/troncgame/fight/FightLogic.java
+++ b/core/src/fr/mmyumu/troncgame/fight/FightLogic.java
@@ -88,6 +88,8 @@ public class FightLogic {
             case ACTION_SELECTED:
                 if (selectedIcon.isAction()) {
                     fightState = FightState.ACTION_SELECTED;
+                } else {
+                    fightState = FightState.CHARACTER_SELECTED;
                 }
                 popUpMenuLogic.selectIcon(touchedIcon);
                 break;
@@ -188,10 +190,6 @@ public class FightLogic {
         return fightMainInfos;
     }
 
-    public void act(float delta) {
-        playAICharacters();
-    }
-
     private void playAICharacters() {
         for (FightCharacter character : enemyFightTeam) {
             if (character.getCharacter().getHp() > 0 && character.isReady()) {
@@ -204,5 +202,33 @@ public class FightLogic {
     private FightCharacter computeTargetCharacter() {
         int random = ThreadLocalRandom.current().nextInt(0, fightTeam.size());
         return fightTeam.get(random);
+    }
+
+    public void update(float delta) {
+        playAICharacters();
+
+        switch(fightState) {
+            case NOTHING_SELECTED:
+                fightBackground.setDarkened(false);
+                darkenCharacters(fightTeam, false);
+                darkenCharacters(enemyFightTeam, false);
+                break;
+            case CHARACTER_SELECTED:
+                fightBackground.setDarkened(true);
+                darkenCharacters(fightTeam, true);
+                darkenCharacters(enemyFightTeam, true);
+                break;
+            case ACTION_SELECTED:
+                fightBackground.setDarkened(true);
+                darkenCharacters(fightTeam, true);
+                darkenCharacters(enemyFightTeam, false);
+                break;
+        }
+    }
+
+    private void darkenCharacters(List<FightCharacter> characters, boolean darkened) {
+        for (FightCharacter character : characters) {
+            character.setDarkened(darkened);
+        }
     }
 }

--- a/core/src/fr/mmyumu/troncgame/fight/FightScreen.java
+++ b/core/src/fr/mmyumu/troncgame/fight/FightScreen.java
@@ -111,10 +111,10 @@ public class FightScreen extends ScreenAdapter implements Musical, InputProcesso
         if (fightLogic.isEnded()) {
             endFight();
         } else {
+            fightLogic.update(delta);
             fightGame.act(delta);
             fightUI.act(delta);
             fightPopUpMenu.act(delta);
-            fightLogic.act(delta);
         }
     }
 


### PR DESCRIPTION
The background is darkened when the popup menu is displayed.
The enemy characters are darkened when using the menu, but they are not darkened
when an action is selected (it should be improved when some actions can
target allies).

Issue #93
